### PR TITLE
Made logLevelToString() static to avoid compilation issues

### DIFF
--- a/include/EmbedLog/Types.hpp
+++ b/include/EmbedLog/Types.hpp
@@ -51,7 +51,7 @@ enum class LogLevel : uint8_t
  * @param level The LogLevel to be converted.
  * @return A string representing the log level, with ANSI color codes for formatting.
  */
-std::string logLevelToString(LogLevel level)
+static std::string logLevelToString(LogLevel level)
 {
     switch (level)
     {


### PR DESCRIPTION
This pull request fixes a compilation issue by making logLevelToString() static.