### PR TITLE
Made year field of TimeStamp a uint16_t

### DIFF
--- a/include/EmbedLog/Types.hpp
+++ b/include/EmbedLog/Types.hpp
@@ -101,7 +101,7 @@ struct TimeStamp
     uint8_t  hours;
     uint8_t  day;
     uint8_t  month;
-    uint8_t  year;
+    uint16_t year;
 };
 
 /**


### PR DESCRIPTION
This pull request fixes a bug whereby the year field of the TimeStamp struct was stored as a uint8_t, meaing it would overflow at 255 and not allows 4 digit year values.