### PR TITLE
Getting rid of annoying warnings when compiling under more strict flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,6 @@ project(EmbedLog)
 
 add_library(EmbedLog INTERFACE)
 
-target_include_directories(EmbedLog INTERFACE
+target_include_directories(EmbedLog SYSTEM INTERFACE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )

--- a/include/EmbedLog/Types.hpp
+++ b/include/EmbedLog/Types.hpp
@@ -51,7 +51,7 @@ enum class LogLevel : uint8_t
  * @param level The LogLevel to be converted.
  * @return A string representing the log level, with ANSI color codes for formatting.
  */
-std::string logLevelToString(LogLevel level)
+static std::string logLevelToString(LogLevel level)
 {
     switch (level)
     {
@@ -101,7 +101,7 @@ struct TimeStamp
     uint8_t  hours;
     uint8_t  day;
     uint8_t  month;
-    uint8_t  year;
+    uint16_t year;
 };
 
 /**


### PR DESCRIPTION
It just exports the library as a system-wise library so the warnings are not propagated into it.